### PR TITLE
fix: primary label now in pod instance to avoid forbidden fields update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 vendor
+.idea
+.idea/*


### PR DESCRIPTION
When pod is selected to be primary in mongodb cluster and the set of labes are replaced the api response indicates a forbbiden field error. To avoid this error, the labels are not replaced and are handled directly in current pod instance.