### PR TITLE
logging: improve structured output and error context

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,11 @@ The repository includes an end-to-end test environment in `test/integration`.
 
 Prerequisites:
 
-- `kind`
-- `kubectl`
-- Docker with BuildKit/Buildx enabled
+- [kind](https://kind.sigs.k8s.io/)
+- [kubectl](https://kubernetes.io/docs/reference/kubectl/)
+- [Docker](https://www.docker.com/)
+- [BuildKit](https://github.com/moby/buildkit)
+- [Buildx](https://github.com/docker/buildx)
 
 Run:
 
@@ -101,8 +103,8 @@ The repository uses a single workflow for GitHub and local runs: `.github/workfl
 
 Prerequisites:
 
-- Docker Desktop running
-- `act` installed
+- [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+- [act](https://github.com/nektos/act)
 
 Run the full workflow locally:
 

--- a/main_test.go
+++ b/main_test.go
@@ -284,6 +284,7 @@ func TestSetPrimaryLabel_PrimaryResolverError(t *testing.T) {
 	err := labeler.setPrimaryLabel()
 	require.Error(t, err)
 	require.ErrorIs(t, err, primaryErr)
+	require.ErrorContains(t, err, "resolve primary pod name")
 	assert.Empty(t, k8sClient.Actions())
 }
 
@@ -296,6 +297,7 @@ func TestSetPrimaryLabel_ListPodsError(t *testing.T) {
 
 	err := labeler.setPrimaryLabel()
 	require.Error(t, err)
+	assert.ErrorContains(t, err, "list pods in namespace")
 	assert.ErrorContains(t, err, "forbidden")
 }
 
@@ -318,6 +320,7 @@ func TestSetPrimaryLabel_StopsAfterPatchError(t *testing.T) {
 	err := labeler.setPrimaryLabel()
 	require.Error(t, err)
 	require.ErrorIs(t, err, patchErr)
+	require.ErrorContains(t, err, "patch pod \"mongo-1\" primary label")
 
 	patchedPods := []string{}
 	for _, action := range k8sClient.Actions() {


### PR DESCRIPTION
## Summary
- Use structured phuslog fields instead of printf-style messages for startup config and primary label changes
- Wrap errors with contextual messages (namespace, selector, pod name, mongo address) to aid debugging
- Track last-known primary to distinguish initial detection from failover events
- Link prerequisite tools in README

## Test plan
- [x] `go test ./...` passes
- [ ] `golangci-lint run` passes in CI
- [ ] Integration test passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)