### PR TITLE
build(deps): bump github/codeql-action/analyze from 4.37.0 to 4.37.1

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,6 +37,6 @@ jobs:
         dependency-caching: true
 
     - name: Perform CodeQL analysis
-      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4.37.0
+      uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
       with:
         category: "/language:go"


### PR DESCRIPTION
Bumps `github/codeql-action/analyze` from 4.37.0 to 4.37.1, aligning it with `codeql-action/init` which was already bumped to 4.37.1 in #212.

Supersedes #214: that Dependabot branch was cut before #212 merged, so it had `init` at 4.37.0 and `analyze` at 4.37.1. CodeQL rejects mixed action versions (`Loaded a configuration file for version '4.37.0', but running version '4.37.1'`), which is why its "Analyze (Go)" check failed. This PR applies the same bump on top of current master so both steps use v4.37.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)